### PR TITLE
fix #706, using static keys for monitoring items, and set hostname as…

### DIFF
--- a/drivers/api/route.go
+++ b/drivers/api/route.go
@@ -132,6 +132,11 @@ func SetupApiServer(logger hclog.Logger, apiAddr, nomadAddr, consulAddr, uiDir s
 	}
 
 	metricsConfig := metrics.DefaultConfig("dtle")
+
+	// adding hostname to labels, and don't set it as a prefix to gauge values.
+	metricsConfig.EnableHostname = false
+	metricsConfig.EnableHostnameLabel = true
+
 	_, err = metrics.NewGlobal(metricsConfig, sink)
 	if err != nil {
 		return err


### PR DESCRIPTION
… a lable