### PR TITLE
fix diagnosis bug : archive tar/: write too long

### DIFF
--- a/api/handler/v2/job.go
+++ b/api/handler/v2/job.go
@@ -2216,10 +2216,9 @@ func DiagnosisJobAndTarFile(logger g.LoggerType, jobId, src, dst string) (err er
 		if err != nil {
 			return err
 		}
-
-		_, err = io.Copy(tw, fr)
+		_, err = io.CopyN(tw, fr, fi.Size())
 		if err != nil {
-			return err
+			return fmt.Errorf("write file %s err: %v", hdr.Name, err)
 		}
 		return nil
 	})


### PR DESCRIPTION
the log file may continue to grow and needs to be written to the specified size